### PR TITLE
remove fixed overflow mode for axisName

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -425,7 +425,8 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
         const truncateOpt = axisModel.get('nameTruncate', true) || {};
         const ellipsis = truncateOpt.ellipsis;
         const maxWidth = retrieve(
-            opt.nameTruncateMaxWidth, truncateOpt.maxWidth, axisNameAvailableWidth
+            opt.nameTruncateMaxWidth, truncateOpt.maxWidth, axisNameAvailableWidth,
+            textStyleModel.get('width') as number
         );
 
         const textEl = new graphic.Text({
@@ -436,7 +437,6 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
             style: createTextStyle(textStyleModel, {
                 text: name,
                 font: textFont,
-                overflow: 'truncate',
                 width: maxWidth,
                 ellipsis,
                 fill: textStyleModel.getTextColor()

--- a/test/radar-axisName.html
+++ b/test/radar-axisName.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+        <div id="main1"></div>
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option;
+
+            option = {
+                radar: {
+                    axisName: {
+                        color: 'black',
+                        width: 100,
+                        overflow: 'break',
+                    },
+                    indicator: [
+                    { name: 'Sales'},
+                    { name: 'Administration'},
+                    { name: 'Information Techology'},
+                    { name: 'Customer Support'},
+                    { name: 'Development'},
+                    { name: 'Marketing'}
+                    ]
+                },
+                series: [{
+                    name: 'Budget vs spending',
+                    type: 'radar',
+                    data : [
+                        {
+                            value : [4300, 10000, 28000, 35000, 50000, 19000],
+                            name : 'Allocated Budget'
+                        },
+                        {
+                            value : [5000, 14000, 28000, 31000, 42000, 21000],
+                            name : 'Actual Spending'
+                        }
+                    ]
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Check break for radar axisName overflow',
+                    'The overflowing axisNames ("Information Technology" and "Customer support") should be broken up to 2 lines each.'
+                ],
+                option: option
+            });
+
+            // second chart
+            const option2 = {
+                radar: {
+                    axisName: {
+                        color: 'black',
+                        width: 100,
+                        overflow: 'truncate',
+                    },
+                    indicator: [
+                    { name: 'Sales'},
+                    { name: 'Administration'},
+                    { name: 'Information Techology'},
+                    { name: 'Customer Support'},
+                    { name: 'Development'},
+                    { name: 'Marketing'}
+                    ]
+                },
+                series: [{
+                    name: 'Budget vs spending',
+                    type: 'radar',
+                    data : [
+                        {
+                            value : [4300, 10000, 28000, 35000, 50000, 19000],
+                            name : 'Allocated Budget'
+                        },
+                        {
+                            value : [5000, 14000, 28000, 31000, 42000, 21000],
+                            name : 'Actual Spending'
+                        }
+                    ]
+                }]
+            };
+
+            const chart2 = testHelper.create(echarts, 'main1', {
+                title: [
+                    'Check ellipsis for radar axisName overflow',
+                    'The overflowing axisNames ("Information Technology" and "Customer support") should be shortened to 100px width'
+                ],
+                option: option2
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x ] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Use textStyleModel.width as maxWidth fallback in AxisLabelText



### Fixed issues

<!--
- #17209: [Bug] On Radar Chart Axis name Overflow property is not working
-->


## Details

### Before: What was the problem?

MaxWidth of radar chart labels could not be set.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

MaxWidth of radar chart label can be set by setting TextStyleModel.width

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
